### PR TITLE
Adjustments of array classes

### DIFF
--- a/src/array.h
+++ b/src/array.h
@@ -5,233 +5,239 @@
 
 namespace cype {
 
-//	array with `IType`(Index Type), `IndexedType`(index-templated value type) and index values
-	template <class IType, template <IType> class IndexedType, IType... _Indexes>
-	class array_index_args_of : public typed_set<IndexedType<_Indexes>...> {
-		using base_type = typed_set<IndexedType<_Indexes>...>;
+//	array with index type, index-templated value type, index values
+	template <
+		class IType,					//	index type
+		template <IType> class Idxed	//	index-templated value type
+	>
+	struct array_itype_idxed_of : _static_class {
 
-	//	to avoid MSVC's bug
-		template <IType _Index>
-		using original_type_at = typename IndexedType<_Index>::original_type;
+		template <IType... Is>						//	index value(s)
+		class iargs_of : public typed_set<Idxed<Is>...> {
+			using base_type = typed_set<Idxed<Is>...>;
 
-	public:
-		using this_type = array_index_args_of;
+		//	to avoid MSVC's bug
+			template <IType I>
+			using original_type_at = typename Idxed<I>::original_type;
 
-		template <IType _I>
-		using my_indexed_type = IndexedType<_I>;
+		public:
+			using this_type = iargs_of;
+			using this_indexes = tmplval_list<IType, Is...>;
 
-		using my_indexes = tmplval_list<IType, _Indexes...>;
+			template <IType _I>
+			using this_indexed_type = Idxed<_I>;
 
-		using base_type::base_type;
-		using base_type::get;
-		using base_type::get_ref;
-		using base_type::extract;
-		using base_type::extract_to;
-		using base_type::set;
-		using base_type::size;
+			using base_type::base_type;
+			using base_type::get;
+			using base_type::get_ref;
+			using base_type::extract;
+			using base_type::extract_to;
+			using base_type::set;
+			using base_type::size;
 
 
-	//	default constructor
-		array_index_args_of() = default;
+		//	default constructor
+			iargs_of() = default;
 	
-	//	construct from base type	
-		array_index_args_of(const base_type& v) : base_type(v) {}
+		//	construct from base type	
+			iargs_of(const base_type& v) : base_type(v) {}
 
-	//	construct with indexed values
-		array_index_args_of(IndexedType<_Indexes>... vals) noexcept
-			: base_type(vals...) {}
+		//	construct with indexed values
+			iargs_of(Idxed<Is>... vals) noexcept
+				: base_type(vals...) {}
 
-	//	construct with non-indexed (original) values
-		array_index_args_of(original_type_at<_Indexes>... vals) noexcept
-		 	: base_type(IndexedType<_Indexes>(vals)...) {}
+		//	construct with non-indexed (original) values
+			iargs_of(original_type_at<Is>... vals) noexcept
+		 		: base_type(Idxed<Is>(vals)...) {}
 
-	//	construct from different typed array
-		template <template <IType> class _IndexedType>
-		array_index_args_of(const array_index_args_of<IType, _IndexedType, _Indexes...>& arr)
-			: base_type(IndexedType<_Indexes>(arr.template get<_Indexes>())...) {}
+		//	construct from different typed array
+			template <class _IType, template <_IType> class _Idxed>
+			iargs_of(const typename array_itype_idxed_of<_IType, _Idxed>::template iargs_of<Is...>& arr)
+				: base_type(Idxed<Is>(arr.template get<Is>())...) {}
 
-	//	construct with single value
-		template <class _Type>
-		explicit array_index_args_of(const typename IndexedType<0>::original_type& val)
-			: base_type(IndexedType<_Indexes>(val)...) {}
+		//	construct with single value
+			explicit iargs_of(const typename Idxed<0>::original_type& val)
+				: base_type(Idxed<Is>(val)...) {}
 
 
-	//	get value of specified index
-		template <IType _Index>
-		IndexedType<_Index>
-		get() const noexcept {
-			return base_type::template get<IndexedType<_Index>>();
-		}
+		//	get value of specified index
+			template <IType I>
+			Idxed<I>
+			get() const noexcept {
+				return base_type::template get<Idxed<I>>();
+			}
 		
-	//	extract values of specified indexes
-		template <IType... __Indexes>
-		array_index_args_of<IType, IndexedType, __Indexes...>
-		extract() const noexcept {
-			return {*this};
-		}
+		//	extract values of specified indexes
+			template <IType... _Is>
+			iargs_of<_Is...>
+			extract() const noexcept {
+				return {*this};
+			}
 
-	//	extract values to other indexed array
-		template <IType... __Indexes>
-		void extract_to(array_index_args_of<IType, IndexedType, __Indexes...>& out) noexcept {
-			_void{(out.set<__Indexes>(get<__Indexes>()), 0)...};
-		}
+		//	extract values to other indexed array
+			template <IType... _Is>
+			void extract_to(iargs_of<_Is...>& out) noexcept {
+				_void{(out.set<_Is>(get<_Is>()), 0)...};
+			}
 
-	//	get raw (original) typed value of specified index
-		template <IType _Index>
-		typename IndexedType<_Index>::original_type
-		get_raw() const noexcept {
-			return (typename IndexedType<_Index>::original_type)get<_Index>();
-		}
+		//	get raw (original) typed value of specified index
+			template <IType I>
+			typename Idxed<I>::original_type
+			get_raw() const noexcept {
+				return (typename Idxed<I>::original_type)get<I>();
+			}
 
-	//	rearrange (change order of) values and get new array
-		template <IType... __Indexes>
-		this_type rearrange() const noexcept {
-			return {get_raw<__Indexes>()...};
-		}
+		//	rearrange (change order of) values and get new array
+			template <IType... _Is>
+			this_type rearrange() const noexcept {
+				return {get_raw<_Is>()...};
+			}
 
-	//	reindex (set new indexes to) values and get new array
-		template <IType... __Indexes>
-		array_index_args_of<IType, IndexedType, __Indexes...>
-		reindex_with_args() const noexcept {
-			return {get_raw<_Indexes>()...};
-		}
+		//	reindex (set new indexes to) values and get new array
+			template <IType... _Is>
+			iargs_of<_Is...>
+			reindex_with_args() const noexcept {
+				return {get_raw<Is>()...};
+			}
 
-	private:
-	//	helper class for function call with index list
-		template <IType... __Indexes>
-		struct with_index_args_of : _static_class {
+		private:
+		//	helper class for function call with index list
+			template <IType... _Is>
+			struct with_iargs : _static_class {
 			
-			static this_type
-			rearrange(const this_type& arr) noexcept {
-				return arr.rearrange<__Indexes...>();
+				static this_type
+				rearrange(const this_type& arr) noexcept {
+					return arr.rearrange<_Is...>();
+				}
+
+				static iargs_of<_Is...>
+				reindex_with_args(const this_type& arr) noexcept {
+					return arr.reindex_with_args<_Is...>();
+				}
+
+			};
+
+		public:
+			template <class IdxList>
+			this_type rearrange() const noexcept {
+				return IdxList::template apply_to<with_iargs>::rearrange(*this);
+			}
+		
+			template <class IdxList>
+			auto reindex() const noexcept {
+				return IdxList::template apply_to<with_iargs>::reindex_with_args(*this);
 			}
 
-			static array_index_args_of<IType, IndexedType, __Indexes...>
-			reindex_with_args(const this_type& arr) noexcept {
-				return arr.reindex_with_args<__Indexes...>();
+			template <IType _IStart>
+			auto reindex() const noexcept {
+				return reindex<sequence<IType, _IStart, _IStart + size - 1>>();
 			}
+
+			auto reindex() const noexcept {
+				return reindex<0>();
+			}
+
+		
+
+		//	set value of specified index
+			template <IType I>
+			void set(const Idxed<I>& val) noexcept {
+				base_type::template set(val);
+			}
+
+		//	set value of specified index using raw (original) typed value
+			template <IType I>
+			void set(const typename Idxed<I>::original_type& val) noexcept {
+				base_type::template set((const Idxed<I>&)val);
+			}
+
+
+		//	fill same value to all indexes
+			template <class T>
+			void fill(const T& val) noexcept {
+				_void{(set<Is>((const typename Idxed<Is>::original_type&)val), 0)...};
+			}
+
+		//	cast to another indexed-type
+			template <template <IType> class _Idxed>
+			iargs_of<Is...>
+			cast_to() const {
+				return {*this};
+			}
+
 
 		};
 
-	public:
-		template <class IndexList>
-		this_type rearrange() const noexcept {
-			return IndexList::template apply_to<with_index_args_of>::rearrange(*this);
-		}
+
+		template <class IdxList>
+		using index_list_of = typename IdxList::template apply_to<iargs_of>;
 		
-		template <class IndexList>
-		auto reindex() const noexcept {
-			return IndexList::template apply_to<with_index_args_of>::reindex_with_args(*this);
-		}
+	//	array with index type, index-templated value type, range of index values
+		template <
+			IType _First,					//	first value of index
+			IType _Last,					//	last value of index
+			class DiffType = IType,			//	difference type of index
+			DiffType _Inv = 1				//	interval of index values
+		>
+		using range_of = index_list_of<sequence<IType, _First, _Last, DiffType, _Inv>>;
 
-		template <IType _IStart>
-		auto reindex() const noexcept {
-			return reindex<sequence<IType, _IStart, _IStart + size - 1>>();
-		}
-
-		auto reindex() const noexcept {
-			return reindex<0>();
-		}
-
-		
-
-	//	set value of specified index
-		template <IType _Index>
-		void set(const IndexedType<_Index>& val) noexcept {
-			base_type::template set(val);
-		}
-
-	//	set value of specified index using raw (original) typed value
-		template <IType _Index>
-		void set(const typename IndexedType<_Index>::original_type& val) noexcept {
-			base_type::template set((const IndexedType<_Index>&)val);
-		}
-
-
-	//	fill same value to all indexes
-		template <class _Type>
-		void fill(const _Type& val) noexcept {
-			_void{(set<_Indexes>((const typename IndexedType<_Indexes>::original_type&)val), 0)...};
-		}
-
-	//	cast to another indexed-type
-		template <template <IType> class _IndexedType>
-		array_index_args_of<IType, _IndexedType, _Indexes...>
-		cast_to() const {
-			return {*this};
-		}
-
-
-	};
-
-
-
-//	array with `IType`(Index Type), `ValType`(Value Type) and index values
-	template <class IType, class ValType, IType... _Indexes>
-	using array_type_index_args_of = array_index_args_of<size_t, indexed_types<ValType, size_t>::template single_type, _Indexes...>;
-
-
-//	preset template arguments `IType` and `IndexedType` of `array_index_args_of` class
-	template <class IType, template <IType> class IndexedType>
-	struct _array_preset_indexed : _static_class {
-		template <IType... _Indexes>
-		using indexes_of = array_index_args_of<IType, IndexedType, _Indexes...>;
-	};
-
-
-//	preset template arguments `IType` and `ValType` of `array_type_index_args_of` class
-	template <class IType, class ValType>
-	struct _array_preset_valtype : _static_class {
-		template <IType... _Indexes>
-		using indexes_of = array_type_index_args_of<IType, ValType, _Indexes...>;
-	};
-
-
-//	array with `IType`(index type), `IndexedType`(index-templated value type) and list of index values
-	template <class IndexList, template <typename IndexList::tmplval_type> class IndexedType>
-	using array_indexes_of = typename IndexList::template apply_to<_array_preset_indexed<typename IndexList::tmplval_type, IndexedType>::template indexes_of>;
-		
-//	array with `IType`(index type), `IndexedType`(index-templated value type) and range of index values
-	template <class IType, template <IType> class IndexedType, IType _First, IType _Last, class DiffType = IType, DiffType _Inv = 1>
-	using array_range_of = array_indexes_of<
-		sequence<IType, _First, _Last, DiffType, _Inv>,
-		IndexedType
-	>;
-
-//	array with `size_t` index, `IndexedType`(index-templated value type) and number of index values
-	template <template <size_t> class IndexedType, size_t _Size>
-	using array_of_indexed = array_range_of<size_t, IndexedType, 0, _Size - 1>;
+	//	array with `size_t` index, `Idxed`(index-templated value type), number of index values
+		template <size_t Sz>
+		using size_of = range_of<0, Sz - 1>;
 	
 
+	};
+
+//	array with `IType`(Index Type), `ValType`(Value Type) and index values
+	template <class IType,	class ValType>
+	using array_itype_valtype_of = array_itype_idxed_of<
+		IType,
+		indexed_types<ValType, IType>::template single_type
+	>;
+
+	template <class IdxList, template <typename IdxList::tmplval_type> class Idxed>
+	using array_idxlist_idxed_of = 
+		typename array_itype_idxed_of<typename IdxList::tmplval_type, Idxed>
+		::template index_list_of<IdxList>;
+
 //	array with `IType`(index type), `ValType`(value type) and list of index values
-	template <class IndexList, class ValType>
-	using array_type_indexes_of = typename IndexList::template apply_to<_array_preset_valtype<typename IndexList::tmplval_type, ValType>::template indexes_of>;
+	template <class IdxList, class ValType>
+	using array_idxlist_valtype_of = 
+		typename array_itype_valtype_of<typename IdxList::tmplval_type, ValType>
+		::template index_list_of<IdxList>;
 		
-//	array with `IType`(index type), `ValType`(value type) and range of index values
-	template <class IType, class ValType, IType _First, IType _Last, class DiffType = IType, DiffType _Inv = 1>
-	using array_type_range_of = array_type_indexes_of<
+//	array with index type, value type, range of index values
+	template <
+		class IType,			//	index type
+		class ValType,			//	value type
+		IType _First,			//	first value of index
+		IType _Last,			//	last value of index
+		class DiffType = IType,	//	difference type of index
+		DiffType _Inv = 1		//	interval of index values
+	>
+	using array_itype_valtype_range_of = array_idxlist_valtype_of<
 		sequence<IType, _First, _Last, DiffType, _Inv>,
 		ValType
 	>;
 
 //	array with size_t index, `ValType`(value type) and number of index values
 	template <class ValType, size_t _Size>
-	using array_of_type = array_type_range_of<size_t, ValType, 0, _Size - 1>;
+	using array_valtype_size_of = array_itype_valtype_range_of<size_t, ValType, 0, _Size - 1>;
 	
 
 //	alias of array_type_of
 	template <class ValType, size_t _Size>
-	using array = array_of_type<ValType, _Size>;
+	using array = array_valtype_size_of<ValType, _Size>;
 
 
 //	natural typed array (index starts from 1, not 0)
 	template <class ValType, size_t _Size>
-	using natural_array = array_type_range_of<size_t, ValType, 1, _Size>;
+	using natural_array = array_itype_valtype_range_of<size_t, ValType, 1, _Size>;
 
 
 //	construct array with values
 	template <class First, class... Rests>
-	array_of_type<First, sizeof...(Rests) + 1>
+	array<First, sizeof...(Rests) + 1>
 	make_array(const First& first, Rests&&... rests) {
 		return {first, rests...};
 	}

--- a/src/array_2d.h
+++ b/src/array_2d.h
@@ -4,52 +4,68 @@
 
 namespace cype {
 	
-	template <template <size_t, size_t> class DoubleIndexed, class ISeq1, class ISeq2>
-	using array_2d_of_indexed_base = array_indexes_of<
-		typename _preset_double_index<DoubleIndexed>::template preset_index_sequences<ISeq1, ISeq2>::indexes,
-		_preset_double_index<DoubleIndexed>::template preset_index_sequences<ISeq1, ISeq2>::template type
+//	base type of `array_2d_iseqs` class
+	template <
+		template <size_t, size_t> class DblIdxed,
+		class ISeq1,
+		class ISeq2
+	>
+	using array_2d_of_indexed_base = array_idxlist_idxed_of<
+		typename _preset_double_index<DblIdxed>::template preset_index_sequences<ISeq1, ISeq2>::indexes,
+		_preset_double_index<DblIdxed>::template preset_index_sequences<ISeq1, ISeq2>::template type
 	>;
 
-
-	template <template <size_t, size_t> class DoubleIndexed, class ISeq1, class ISeq2>
-	class array_2d_of_indexed : public array_2d_of_indexed_base<DoubleIndexed, ISeq1, ISeq2> {
+//	2-dimensional array
+	template <
+		template <size_t, size_t> class DblIdxed,	//	2 indexes-templated value type
+		class ISeq1,	//	sequence (tmplval_list) of index-1
+		class ISeq2		//	sequence (tmplval_list) of index-2
+	>
+	class array_2d_dblidxed_iseqs : public array_2d_of_indexed_base<DblIdxed, ISeq1, ISeq2> {
 	public:
-		using this_type = array_2d_of_indexed;
-		using base_type = array_2d_of_indexed_base<DoubleIndexed, ISeq1, ISeq2>;
+		using this_type = array_2d_dblidxed_iseqs;
+		using this_indexes_1 = ISeq1;
+		using this_indexes_2 = ISeq2;
+
+		template <size_t _I1, size_t _I2>
+		using this_double_indexed_type = DblIdxed<_I1, _I2>;
+
+		using base_type = array_2d_of_indexed_base<DblIdxed, ISeq1, ISeq2>;
 		using base_type::base_type;
 		using base_type::get;
+		using base_type::get_raw;
 		using base_type::set;
 
 	//	get value of specified index pair
 		template <size_t _I1, size_t _I2>
-		DoubleIndexed<_I1, _I2>
+		DblIdxed<_I1, _I2>
 		get() const noexcept {
-			return base_type::template get<DoubleIndexed<_I1, _I2>>();
+			return base_type::template get<DblIdxed<_I1, _I2>>();
 		}
 
 	//	get raw (original) typed value of specified index
 		template <size_t _I1, size_t _I2>
-		typename DoubleIndexed<_I1, _I2>::original_type
+		typename DblIdxed<_I1, _I2>::original_type
 		get_raw() const noexcept {
-			return (typename DoubleIndexed<_I1, _I2>::original_type)get<_I1, _I2>();
+			return (typename DblIdxed<_I1, _I2>::original_type)get<_I1, _I2>();
 		}
 
 
 	//	set value of specified index
 		template <size_t _I1, size_t _I2>
-		void set(const DoubleIndexed<_I1, _I2>& val) noexcept {
+		void set(const DblIdxed<_I1, _I2>& val) noexcept {
 			base_type::template set(val);
 		}
 
 	//	set value of specified index using raw (original) typed value
 		template <size_t _I1, size_t _I2>
-		void set(const typename DoubleIndexed<_I1, _I2>::original_type& val) noexcept {
-			base_type::template set((const DoubleIndexed<_I1, _I2>&)val);
+		void set(const typename DblIdxed<_I1, _I2>::original_type& val) noexcept {
+			base_type::template set((const DblIdxed<_I1, _I2>&)val);
 		}
 
 	//	cast to another indexed-type
-		template <template <size_t, size_t> class _DoubleIndexed>
-		array_2d_of_indexed<_DoubleIndexed, ISeq1, ISeq2>
+		template <template <size_t, size_t> class _DblIdxed>
+		array_2d_dblidxed_iseqs<_DblIdxed, ISeq1, ISeq2>
 		cast_to() const {
 			return {*this};
 		}
@@ -60,7 +76,7 @@ namespace cype {
 		class _index_1_of : _static_class {
 		private:
 			template <size_t _I2>
-			static constexpr size_t c_index = _preset_double_index<DoubleIndexed>
+			static constexpr size_t c_index = _preset_double_index<DblIdxed>
 				::template preset_index_sequences<ISeq1, ISeq2>
 				::template preset_index_1<_I1>
 				::template index<_I2>;
@@ -85,7 +101,7 @@ namespace cype {
 		struct _index_2_of : _static_class {
 		private:
 			template <size_t _I1>
-			static constexpr size_t c_index = _preset_double_index<DoubleIndexed>
+			static constexpr size_t c_index = _preset_double_index<DblIdxed>
 				::template preset_index_sequences<ISeq1, ISeq2>
 				::template preset_index_2<_I2>
 				::template index<_I1>;
@@ -148,26 +164,28 @@ namespace cype {
 
 
 	template <class ValType, class ISeq1, class ISeq2>
-	using array_2d_of_type = array_2d_of_indexed<
+	using array_2d_type_iseqs = array_2d_dblidxed_iseqs<
 		indexed_types<ValType, size_t>::template double_type,
 		ISeq1,
 		ISeq2
 	>;
 	
 
-	template <class ValType, size_t _Sz1, size_t _Sz2>
-	using array_2d = array_2d_of_type<
+	template <class ValType, size_t Sz1, size_t Sz2>
+	using array_2d_type_of = array_2d_type_iseqs<
 		ValType,
-		index_sequence<0, _Sz1 - 1>,
-		index_sequence<0, _Sz2 - 1>
+		index_sequence<0, Sz1 - 1>,
+		index_sequence<0, Sz2 - 1>
 	>;
 
-	template <class ValType, size_t _Sz1, size_t _Sz2>
-	using natural_array_2d = array_2d_of_type<
-		ValType,
-		index_sequence<1, _Sz1>,
-		index_sequence<1, _Sz2>
-	>;
+	template <class ValType, size_t Sz1, size_t Sz2>
+	using array_2d = array_2d_type_of<ValType, Sz1, Sz2>;
 
+	template <class ValType, size_t Sz1, size_t Sz2>
+	using natural_array_2d = array_2d_type_iseqs<
+		ValType,
+		index_sequence<1, Sz1>,
+		index_sequence<1, Sz2>
+	>;
 
 }

--- a/src/md_array.h
+++ b/src/md_array.h
@@ -6,7 +6,7 @@ namespace cype {
 	
 //	multi-dimensional array with `size_t`, `IndexedType`(indexes-templated value type) and sizes of each dimension
 	template <template <size_t...> class MultiIndexedType, size_t... _Sizes>
-	using _md_array_of_indexed_base = array_indexes_of<
+	using _md_array_of_indexed_base = array_idxlist_idxed_of<
 		typename _md_indexed_size_args_of<size_t, MultiIndexedType, _Sizes...>::indexes,
 		_md_indexed_size_args_of<size_t, MultiIndexedType, _Sizes...>::template type
 	>;

--- a/src/tmplval_list.h
+++ b/src/tmplval_list.h
@@ -149,6 +149,12 @@ namespace cype {
 		template <size_t _Index>
 		static constexpr ValType get = _get<_Index>();
 
+	//	get first value
+		static constexpr ValType first = get<0>;
+
+	//	get last value
+		static constexpr ValType last = get<size - 1>;
+
 	//	get particial list
 		template <size_t _FirstIndex, size_t _LastIndex>
 		using range_of = typename decltype(_range_of<_FirstIndex, _LastIndex>())::type;

--- a/src/type_utils.h
+++ b/src/type_utils.h
@@ -4,33 +4,32 @@
 #include "_utility.h"
 
 namespace cype {
-namespace type_utils {
 
 //	returns true if _Type1 equals to _Type2
 	template <class _Type1, class _Type2>
-	constexpr bool is_same = std::is_same_v<_Type1, _Type2>;
+	constexpr bool is_same_type = std::is_same_v<_Type1, _Type2>;
 
 //	list of types
 	template <class... Types>
-	class list;
+	class type_list;
 	
 //	specialization of `list` which has type(s)
 	template <class First, class... Rests>
-	class list<First, Rests...> : _static_class {
+	class type_list<First, Rests...> : _static_class {
 	public:
 		template <class... Types>
-		friend class list;
+		friend class type_list;
 
 	//	push new value(s) to back
 		template <class... _Types>
-		using push_back = list<First, Rests..., _Types...>;
+		using push_back = type_list<First, Rests..., _Types...>;
 		
 	//	push new value(s) to front
 		template <class... _Types>
-		using push_front = list<_Types..., First, Rests...>;
+		using push_front = type_list<_Types..., First, Rests...>;
 		
 	//	list of 2nd and later value(s)
-		using rests_list = list<Rests...>;
+		using rests_list = type_list<Rests...>;
 		
 	//	get specified value
 		template <size_t _Index>
@@ -50,7 +49,7 @@ namespace type_utils {
 	//	helper function for `contains`
 		template <class Type>
 		static constexpr bool _contains() {
-			if constexpr(is_same<First, Type>){
+			if constexpr(is_same_type<First, Type>){
 				return true;
 			}else{
 				if constexpr(sizeof...(Rests) != 0){
@@ -91,12 +90,12 @@ namespace type_utils {
 
 	//	get unioned list with new type(s)
 		template <class... _Types>
-		using union_with = typename list<First, Rests..., _Types...>::remove_duplicates;
+		using union_with = typename type_list<First, Rests..., _Types...>::remove_duplicates;
 
 	//	get list without specified type(s)
 		template <class... _Types>
 		using remove = std::conditional_t<
-			list<_Types...>::template contains<First>,
+			type_list<_Types...>::template contains<First>,
 			typename rests_list::template remove<_Types...>,
 			typename rests_list::template remove<_Types...>::template push_front<First>
 		>;
@@ -106,18 +105,18 @@ namespace type_utils {
 
 //	specialization of `list` which has no type
 	template <>
-	class list<> {
+	class type_list<> {
 	public:
 		template <class... Types>
-		friend class list;
+		friend class type_list;
 
 	//	push new type(s) to back
 		template <class... _Types>
-		using push_back = list<_Types...>;
+		using push_back = type_list<_Types...>;
 		
 	//	push new type(s) to front
 		template <class... _Types>
-		using push_front = list<_Types...>;
+		using push_front = type_list<_Types...>;
 
 		template <size_t _Index>
 		using get = void;
@@ -129,12 +128,11 @@ namespace type_utils {
 		template <class _Type>
 		static constexpr bool contains = false;
 
-		using remove_duplicates = list<>;
+		using remove_duplicates = type_list;
 
 		template <class... _Types>
-		using remove = list<>;
+		using remove = type_list;
 
 	};
 
-}
 }

--- a/src/typed_array.h
+++ b/src/typed_array.h
@@ -5,44 +5,68 @@
 
 namespace cype {
 
-	template <class IndexList, class... Types>
-	class typed_array_indexes_of : public array_type_indexes_of<IndexList, typed_set<Types...>> {
-		using base_type = array_type_indexes_of<IndexList, typed_set<Types...>>;
-	public:
-		using base_type::base_type;
-
-		template <class _Type>
-		array_type_indexes_of<IndexList, _Type>
-		get() const {
-			return {*this};
-		}
-
-
-		template <class... _Types>
-		typed_array_indexes_of<IndexList, _Types...>
-		extract() const {
-			return {*this};
-		}
-
-	};
-
-	template <class IndexesType>
-	struct _typed_array_preset_indexes : public _static_class {
+//	multi-typed array (array with typed_set)
+	template <class IdxList>
+	struct typed_array_idxlist_of : _static_class {
+		
 		template <class... Types>
-		using type = typed_array_indexes_of<IndexesType, Types...>;
+		class valtypes_of : public array_idxlist_valtype_of<IdxList, typed_set<Types...>> {
+			using base_type = array_idxlist_valtype_of<IdxList, typed_set<Types...>>;
+		public:
+			using this_type = valtypes_of;
+
+			template <class T>
+			using array_of = array_idxlist_valtype_of<IdxList, T>;
+
+			using base_type::base_type;
+			using base_type::get;
+			using base_type::get_to;
+			using base_type::extract;
+			using base_type::extract_to;
+
+		//	get all values of specified type
+			template <class T>
+			array_of<T> get() const {
+				return {*this};
+			}
+
+		//	get all values of specified type to specified array
+			template <class T>
+			void get_to(array_of<T>& out) const {
+				out = get<T>();
+			}
+
+		//	extract specified types
+			template <class... _Types>
+			valtypes_of<_Types...> extract() const {
+				return {*this};
+			}
+		
+		//	extract specified types to specified typed_array
+			template <class... _Types>
+			void extract_to(valtypes_of<_Types...>& out) const {
+				return out = extract<_Types...>();
+			}
+
+		};
+
+		template <class ValTypeList>
+		using valtypelist_of = typename ValTypeList::template apply_to<valtypes_of>;
+
+
 	};
 
-	template <class IndexesType, class TypeList>
-	using typed_array_indexes_types_of = typename TypeList::template apply_to<_typed_array_preset_indexes<IndexesType>::template type>;
+	template <class IdxList, class ValTypeList>
+	using typed_array_idxlist_valtypelist_of = typename typed_array_idxlist_of<IdxList>::template valtypelist_of<ValTypeList>;
 
 
-	template <size_t _Size, class... Types>
-	using typed_array = typed_array_indexes_of<index_sequence<0, _Size - 1>, Types...>;
+	template <size_t Sz, class... Types>
+	using typed_array_size_valtypes = typename typed_array_idxlist_of<index_sequence<0, Sz - 1>>::template valtypes_of<Types...>;
 
 
 
 	template <class First, class... Rests>
-	typed_array_indexes_types_of<index_sequence<0, sizeof...(Rests)>, typename First::type_list>
+	typed_array_idxlist_valtypelist_of<index_sequence<0, sizeof...(Rests)>, typename First::this_type_list>
 	make_typed_array(const First& first, Rests&&... rests) {
 		return {first, rests...};
 	}

--- a/test/array_2d_test.cpp
+++ b/test/array_2d_test.cpp
@@ -37,13 +37,96 @@ void output_matrix(const MatrixType& mat) {
 }
 
 
-//using matrix44 = array_2d_of_indexed<
-//	_indexed_preset_types<double, size_t>::template double_type,
-//	index_sequence<0, 3>,
-//	index_sequence<0, 3>
-//>;
-
 using matrix44 = natural_array_2d<double, 4, 4>;
+
+//template <size_t NRow, size_t NCol>
+//class matrix : public natural_array_2d<double, 4, 4> {
+//
+//};
+//
+//template <class ValType>
+//struct _matrix_valtype_of : _static_class {
+//
+//	template <size_t IRow, size_t ICol>
+//	using MVal = indexed_types<ValType, size_t>::template double_type<IRow, ICol>;
+//
+//	template <size_t NRows, size_t NCols>
+//	using Matrix = natural_array_2d<ValType, NRows, NCols>;
+//
+//	template <size_t... IRows>
+//	struct rows_of : _static_class {
+//
+//		using row_indexes = tmplval_list<size_t, IRows...>;
+//		static constexpr size_t NRows = row_indexes::size;
+//
+//
+//		template <size_t... ICols>
+//		struct cols_of : _static_class {
+//			
+//			using col_indexes = tmplval_list<size_t, ICols...>;
+//			static constexpr size_t NCols = col_indexes::size;
+//
+//			
+//			using Mat = Matrix<NRows, NCols>; 
+//
+//			static Mat add(const Mat& mat1, const Mat& mat2) {
+//
+//			}
+//
+//			template <size_t... IRCols>
+//			struct lcols_of : _static_class {
+//
+//				using lcol_indexes = tmplval_list<size_t, ILCols...>;
+//				static constexpr size_t NRCols = lcol_indexes::size;
+//
+//				using LMat = Mat;
+//				using RMat = Matrix<NCols, NRCols>;
+//				using MMat = Matrix<NRows, NRCols>;
+//
+//				struct mul_operation {
+//					const LMat lmat;
+//					const RMat rmat;
+//
+//					mul_operation(const LMat& lmat, const RMat& rmat)
+//						: lmat(lmat), rmat(rmat) {}
+//
+//
+//					MMat mul() const {
+//						return mul_lines<row_indexes.first, row_indexes.last>();
+//					};
+//
+//					template <size_t IRow, size_t ICol>
+//					MVal<IRow, ICol> lget() const { return lmat.template get<IRow, ICol>(); }
+//
+//					template <size_t IRow, size_t ICol>
+//					MVal<IRow, ICol> rget() const { return rmat.template get<IRow, ICol>(); }
+//
+//					template <size_t ILine, size_t ILineLast, class... Args>
+//					MMat mul_lines(Args&&... args) const {
+//						if constexpr (ILine > ILineLast) {
+//							return MMat(args...);
+//						}else{
+//							return mul_lines<ILine + 1>(mul_elm<ILine, ICols>()...);
+//						}
+//					}
+//
+//					template <size_t ILRow, size_t IRCol>
+//					MVal<ILRow, IRCol> mul_elm() const {
+//						return (lget<IRows, IRCol>() * rget<ILRow, ICols>() + ...;
+//					}
+//
+//				};
+//
+//
+//			};
+//
+//
+//		};
+//
+//	};
+//
+//};
+//
 
 
 int main(void) {

--- a/test/array_test.cpp
+++ b/test/array_test.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include "array.h"
 
+using namespace cype;
+
 //	sample class `Value`
 template <size_t I>
 struct Value {
@@ -39,7 +41,7 @@ public:
 
 //	sample class `Vector`
 template <size_t N>
-struct Vector : public cype::array_range_of<size_t, ::Value, 1, N> {
+struct Vector : public array_itype_idxed_of<size_t, ::Value>::template range_of<1, N> {
 private:
 
 	struct _OpPlus  { template <class _T> static _T call(_T v) { return +v; } };
@@ -50,13 +52,13 @@ private:
 
 public:
 
-	using _base_type = cype::array_range_of<size_t, ::Value, 1, N>;
+	using base_type = array_itype_idxed_of<size_t, ::Value>::template range_of<1, N>;
 
-	using _base_type::_base_type;
+	using base_type::base_type;
 
 	Vector() = default;
 
-	Vector(const _base_type& v) : _base_type(v) {}
+	Vector(const base_type& v) : base_type(v) {}
 
 
 	void show() const {


### PR DESCRIPTION
- Change name of `type_utils::list` to `type_list`
- Add `get_to`, `extract_to` method on `typed_set` etc.
- Minimize template argument names (e.g. `_Type` to `T`, `_Index` to `I`, `_Indexes` to `Is`)
- Modified class names and structures on `array`, `array_2d`, etc.